### PR TITLE
Callback modifications 

### DIFF
--- a/exports.go
+++ b/exports.go
@@ -18,14 +18,14 @@ import (
 import "C"
 
 //export go_callback
-func go_callback(p1 *C.char, p2 C.uint32_t, p3 unsafe.Pointer) {
+func go_callback(p1 *C.uchar, p2 C.uint32_t, p3 unsafe.Pointer) {
 	// c buffer to go slice without copying
-	var buf []int8
+	var buf []byte
 	length := int(p2)
 	b := (*reflect.SliceHeader)((unsafe.Pointer(&buf)))
 	b.Cap = length
 	b.Len = length
-	b.Data = uintptr(unsafe.Pointer((*int8)(p1)))
+	b.Data = uintptr(unsafe.Pointer(p1))
 	clientCb(buf, (*UserCtx)(p3))
 }
 

--- a/rtlsdr.go
+++ b/rtlsdr.go
@@ -98,7 +98,7 @@ var TunerType = map[int]string{
 	TunerR820T:   "RTLSDR_TUNER_R820T",
 }
 
-type ReadAsyncCb_T func([]int8, *UserCtx)
+type ReadAsyncCb_T func([]byte, *UserCtx)
 
 var clientCb ReadAsyncCb_T
 


### PR DESCRIPTION
Changed the type of the first parameter of the callback function to match its C declaration. Modified it to call the user supplied callback function with a []byte rather than []int8.
