### PR TITLE
goCallback() -> goRTLSDRCallback().

### DIFF
--- a/exports.go
+++ b/exports.go
@@ -18,8 +18,8 @@ import (
 */
 import "C"
 
-//export goCallback
-func goCallback(p1 *C.uchar, p2 C.uint32_t, _ unsafe.Pointer) {
+//export goRTLSDRCallback
+func goRTLSDRCallback(p1 *C.uchar, p2 C.uint32_t, _ unsafe.Pointer) {
 	// c buffer to go slice without copying
 	var buf []byte
 	length := int(p2)

--- a/rtlsdr.go
+++ b/rtlsdr.go
@@ -30,9 +30,9 @@ import (
 #include <rtl-sdr.h>
 #endif
 
-extern void goCallback(unsigned char *buf, uint32_t len, void *ctx);
+extern void goRTLSDRCallback(unsigned char *buf, uint32_t len, void *ctx);
 static inline rtlsdr_read_async_cb_t get_go_cb() {
-	return (rtlsdr_read_async_cb_t)goCallback;
+	return (rtlsdr_read_async_cb_t)goRTLSDRCallback;
 }
 */
 import "C"


### PR DESCRIPTION
`goCallback()` was conflicting with WiringPi Go port. Made it less generic.