### PR TITLE
Using pkg-config and adding Go deps file

### DIFF
--- a/exports.go
+++ b/exports.go
@@ -14,6 +14,7 @@ import (
 )
 
 /*
+#cgo pkg-config: librtlsdr 
 #include <rtl-sdr.h>
 */
 import "C"

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/jpoirier/gortlsdr
+
+go 1.18


### PR DESCRIPTION
Adding the `pkg-config` allows this to easily be installed on systems where librtlsdr doesn't reside in a usual location. For example of newer Mac's.